### PR TITLE
Additions to documentation - sample config and sharing device to another account

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,44 @@ Panasonic Air Conditioner that has a CZ-TACG1 adapter installed
 
 > **Caution!** It is recommended to setup another login for the *Comfort Cloud* and share your home to that login, as opposed to using your regular login for this plugin. Otherwise the *Comfort Cloud* app will log you out each time that you use this plugin (as only one user can be logged into the *Comfort Cloud* per login).
 
-3. Share your login to another user setup specifically for HomeBridge
+3. Share your login to another user setup specifically for HomeBridge.
+   For instructions on how to do this, see [Sharing Panasonic aircon with another account](README.md#Sharing-Panasonic-aircon-with-another-account) section below.
+
+### Sample configuration
+```{
+	"accessories": [
+		{
+		"accessory": "PanasonicAirConditioner",
+		"name": "Bedroom AC",
+		"email": "<YOUR_EMAIL_HERE>",
+		"password": "<YOUR_PASSWORD_HERE>"
+	}]
+```
+
+### Sharing Panasonic aircon with another account
+Panasonic really needs to improve this experience, nonetheless, here it is:
+1. Create a new panasonic account here: [Panasonic ID Registration](https://csapl.pcpf.panasonic.com/Account/Register001?lang=en)
+2. Verify email using the link sent to the email id specified
+3. Sign into the Panasonic Comfort Cloud app on your smart device using the newly created Panasonic ID
+4. Agree to the terms and conditions displayed in app
+5. Agree to the privacy notice displayed in app
+6. You should now be on the home screen of the App
+7. Click the "+" button
+8. Choose "Air Conditioner"
+9. Use the device ID from the original device package
+10. Enter the device password you used when originally setting up the device
+11. In step 3: Enter a name for the aircon, a message="HomeBridge account" and note="HomeBridge account")
+12. Click Send Request
+13. Log out of the app
+14. Sign in with the original email account in the Panasonic Comfort Cloud App
+15. Click the Device you've requested sharing for
+16. Click the hamburger menu and expand the "Owner" menu item, click "User list"
+17. You should now see an id with a waiting approval status
+18. Click the "Waiting Approval" button
+19. Select the "Allow both monitoring and controlling air conditioner" permission
+20. Confirm
+21. The waiting for approval button should have disappeared and replaced with a blue check icon
+22. Use the newly created id in the homekit accessory configuration
 
 ### Legal
 * Licensed under [MIT](LICENSE)


### PR DESCRIPTION
Love your work, though when I tried to set this for the first time, it was one long experience. 
Panasonic really needs to improve their experience around this setup however until that happens, I've made a note of the steps required to set this up the right way. 
Have also added a sample config section to make it easy to pick up and use. 

See if you think this will help others and save some time for a few people.