### PR TITLE
Fix for multiple accessories

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 Panasonic Air Conditioner / Heat Pump plugin for [HomeBridge](https://github.com/nfarina/homebridge) using the Panasonic *Comfort Cloud* API to expose Panasonic Air Conditioners to Apples HomeKit.
 
 ## Things to know
-* Supports only a single Air Conditioner
+* Supports only a single Air Conditioner per Comfort Cloud account
 * Tested only with the *CZ-TACG1* adapter but may support *built-in Wi-Fi adapter* & *CZ-CAPWFC1* adapter
 * Supports *Air Conditioner* and may support *Commercial Air Conditioner*, however I don't think *Air to Water Heat Pump* is supported as these use the *Panasonic AQUAREA* app which is separate
 
@@ -15,12 +15,12 @@ Panasonic Air Conditioner that has a CZ-TACG1 adapter installed
 1. Download, install & setup the *Panasonic Comfort Cloud* app on your mobile device
 2. Create a login & add your Air Conditioner to the *Comfort Cloud*
 
-> **Caution!** It is recommended to setup another login for the *Comfort Cloud* and share your home to that login, as opposed to using your regular login for this plugin. Otherwise the *Comfort Cloud* app will log you out each time that you use this plugin (as only one user can be logged into the *Comfort Cloud* per login).
+> **Caution!** It is recommended to setup another login for the *Comfort Cloud* and share your home to that login, as opposed to using your regular login for this plugin. Otherwise the *Comfort Cloud* app will log you out each time that you use this plugin (as only one user can be logged into the *Comfort Cloud* per login). If you plan to use multiple accessories, create separate accounts for every accessory. 
 
 3. Share your login to another user setup specifically for HomeBridge.
    For instructions on how to do this, see [Sharing Panasonic aircon with another account](README.md#Sharing-Panasonic-aircon-with-another-account) section below.
 
-### Sample configuration
+### Sample configuration for a single AC
 ```{
 	"accessories": [
 		{
@@ -28,6 +28,23 @@ Panasonic Air Conditioner that has a CZ-TACG1 adapter installed
 		"name": "Bedroom AC",
 		"email": "<YOUR_EMAIL_HERE>",
 		"password": "<YOUR_PASSWORD_HERE>"
+	}]
+```
+
+### Sample configuration for multiple ACs
+```{
+	"accessories": [{
+		"accessory": "PanasonicAirConditioner",
+		"name": "Bedroom AC",
+		"email": "<YOUR_EMAIL_HERE>",
+		"password": "<YOUR_PASSWORD_HERE>",
+		"devicenumber": 1
+	},{
+		"accessory": "PanasonicAirConditioner",
+		"name": "Living Room AC",
+		"email": "<YOUR_OTHER_EMAIL_HERE>",
+		"password": "<YOUR_OTHER_PASSWORD_HERE>",
+		"devicenumber": 2
 	}]
 ```
 

--- a/index.js
+++ b/index.js
@@ -27,6 +27,7 @@ function PanasonicAC(log, config) {
 	this.uToken = null;
 
 	this.deviceNumber = config["devicenumber"] || 1;
+	this.groupNumber = config["groupnumber"] || 1;
 	this.version = "1.7.0";
 
 	// Start running the refresh process (login and set timer)
@@ -156,7 +157,7 @@ PanasonicAC.prototype = {
 
 						try {
 							this.log("Login complete");
-							this.device = body['groupList'][this.deviceNumber-1]['deviceIdList'][this.deviceNumber-1]['deviceGuid'];
+							this.device = body['groupList'][this.groupnumber-1]['deviceIdList'][this.deviceNumber-1]['deviceGuid'];
 							this.hcService.getCharacteristic(Characteristic.StatusFault).updateValue(Characteristic.StatusFault.NO_FAULT);
 						}
 						catch(err) {


### PR DESCRIPTION
This will fix the problem setting up multiple accessories with different device numbers. Keep in mind that you need to setup separate panasonic user accounts for each accessory to make it work. 