### PR TITLE
Fix overwriting request error message at login

### DIFF
--- a/index.js
+++ b/index.js
@@ -203,7 +203,10 @@ PanasonicAC.prototype = {
 				}.bind(this));
 			}
 			else {
-				try {this.log("Login failed.", "Error #", body['code'], body['message']);}
+				try {
+					if (err) this.log("Login request failed.", err);
+					else this.log("Login failed.", "Error #", body['code'], body['message']);
+				}
 				catch(err) {this.log("Login failed.", "Unknown error.", "Did the API version change?", err);}
 			}
 		}.bind(this));


### PR DESCRIPTION
Previously, if the underlying TCP/HTTP request threw an error, the `err` was overwritten by the failure to log the `body` object, since no `body` object is present when the underlying request fails.