### PR TITLE
Set and clear intervals and timeouts for refresh, login and login retry

### DIFF
--- a/index.js
+++ b/index.js
@@ -37,16 +37,6 @@ function PanasonicAC(log, config) {
 
 	// Login for the first time and refresh
 	this._login();
-
-	// Set a timer to refresh the data every 10 minutes
-	setInterval(function() {
-		this._refresh();
-	}.bind(this), 600000);
-
-	// Set a timer to refresh the login token every 3 hours
-	setInterval(function() {
-		this._login();
-	}.bind(this), 10800000);
 }
 
 PanasonicAC.prototype = {

--- a/index.js
+++ b/index.js
@@ -132,11 +132,13 @@ PanasonicAC.prototype = {
 	},
 
 	_login: function() {
+		if(this.debug) {this.log("Login start");}
+		
+		// Clear any pending timers
 		clearInterval(this._refreshInterval);
 		clearInterval(this._loginInterval);
 		clearTimeout(this._loginRetry);
-		if(this.debug) {this.log("Login start");}
-
+		
 		// Call the API
 		request.post({
 			url: "https://accsmart.panasonic.com/auth/login/",


### PR DESCRIPTION
Refresh and login token interval is now set after successful login. Login retries are now performed when login does not succeed. Login retries are set with a 5 minute delay, refresh of data and login token use the existing intervals. Intervals are cleared when login is being performed to prevent the intervals from stacking.